### PR TITLE
Update troubleshooting docs about stale log files

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,10 @@
 # Troubleshooting
 
 Common setup or runtime errors and how to resolve them.
+
+## Log files
+
+Stale log files left behind in old directories can lead to misleading errors.
+After the `logs` directory was removed from this repository, make sure to clear
+any remaining log files from previous locations before running the
+application.


### PR DESCRIPTION
## Summary
- document that leftover log files from old locations can cause errors and should be cleared

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842649fe93483209c1db96d9ebc1968