### PR TITLE
Add test requirements reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ ui/
 
 ## Running Tests
 
-Install the development requirements before running the test suite:
+Install the development requirements before running the test suite.
+Remember to run `pip install -r requirements-dev.txt` before executing
+`pytest`.
 
 ```bash
 pip install -r requirements-dev.txt


### PR DESCRIPTION
## Summary
- update README to remind developers to install development requirements before executing tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842649b58f483209c70d0a1bfe8a015