### PR TITLE
Fix imports and logger setup in tests

### DIFF
--- a/tests/test_simple_loader.py
+++ b/tests/test_simple_loader.py
@@ -4,9 +4,12 @@ Simple test to debug the CSV loader service
 """
 
 import io
+import logging
 import pandas as pd
 from services.csv_loader import load_csv_event_log
-from constants import REQUIRED_INTERNAL_COLUMNS
+from config.settings import REQUIRED_INTERNAL_COLUMNS
+
+logger = logging.getLogger(__name__)
 
 def test_loader_debug():
     """Debug the CSV loader service"""

--- a/tests/unit/test_data_processing.py
+++ b/tests/unit/test_data_processing.py
@@ -6,13 +6,16 @@ Unit tests for data processing components - FIXED VERSION
 import pytest
 import pandas as pd
 import io
+import logging
 from unittest.mock import Mock, patch
 
 # FIXED IMPORTS - using your actual project structure
 from services.csv_loader import load_csv_event_log
 from services.secure_file_handler import SecureFileHandler
 from utils.error_handler import ValidationError, DataProcessingError, FileProcessingError
-from constants import REQUIRED_INTERNAL_COLUMNS
+from config.settings import REQUIRED_INTERNAL_COLUMNS
+
+logger = logging.getLogger(__name__)
 
 
 def is_success_result(result) -> bool:


### PR DESCRIPTION
## Summary
- fix imports in `test_simple_loader` and `test_data_processing`
- use settings constant for `REQUIRED_INTERNAL_COLUMNS`
- set up logger for these tests

## Testing
- `pytest -q tests/test_simple_loader.py::test_loader_debug -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684269d9390c83208a533f099867217f