### PR TITLE
Ignore logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 *.pyc
 .DS_Store
 *.env
+logs/
 


### PR DESCRIPTION
## Summary
- ignore `logs/` directory in version control

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684269e5154083208e1a6f25813d8084