### PR TITLE
Fix missing constant imports

### DIFF
--- a/ui/components/mapping.py
+++ b/ui/components/mapping.py
@@ -8,7 +8,8 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 
 from ui.themes.style_config import COLORS, MAPPING_STYLES, get_validation_message_style
-from utils.constants import REQUIRED_INTERNAL_COLUMNS
+# Import required column mapping from unified settings
+from config.settings import REQUIRED_INTERNAL_COLUMNS
 
 
 

--- a/ui/components/upload.py
+++ b/ui/components/upload.py
@@ -8,7 +8,8 @@ from typing import Dict, Any, Optional
 
 # Import from actual structure
 
-from utils.constants import DEFAULT_ICONS
+# Import default icons from unified settings
+from config.settings import DEFAULT_ICONS
 from ui.themes.style_config import (
     COLORS,
     SPACING,

--- a/ui/components/upload_handlers.py
+++ b/ui/components/upload_handlers.py
@@ -16,7 +16,8 @@ from ui.components.upload import create_upload_component
 from ui.themes.graph_styles import upload_icon_img_style
 
 from ui.themes.style_config import UPLOAD_STYLES, get_interactive_setup_style
-from utils.constants import REQUIRED_INTERNAL_COLUMNS
+# Import required column mapping from unified settings
+from config.settings import REQUIRED_INTERNAL_COLUMNS
 
 
 from utils.logging_config import get_logger


### PR DESCRIPTION
## Summary
- load config constants from `config.settings`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684273a89778832083437179567e69a7