### PR TITLE
Fix duplicate IDs in stats charts section

### DIFF
--- a/app.py
+++ b/app.py
@@ -1170,12 +1170,14 @@ def update_floor_display_v6(value):
         Output('charts-section', 'style'),
         Output('export-section', 'style'),
         Output('graph-output-container', 'style'),
+        Output('mini-graph-container', 'style'),
         
         # Basic stats outputs (maintaining compatibility)
         Output('total-access-events-H1', 'children'),
         Output('event-date-range-P', 'children'),
         Output('most-active-devices-table-body', 'children'),
         Output('onion-graph', 'elements'),
+        Output('mini-onion-graph', 'elements'),
         Output('processing-status', 'children', allow_duplicate=True),
         
         # Enhanced stats outputs (if available)
@@ -1232,9 +1234,9 @@ def generate_comprehensive_enhanced_analysis_v6(n_clicks, file_data, processed_d
         hide_style = {'display': 'none'}
         empty_figure = {'data': [], 'layout': {'title': 'No data available', 'plot_bgcolor': '#0F1419', 'paper_bgcolor': '#1A2332', 'font': {'color': '#F7FAFC'}}}
         
-        return ([hide_style] * 6 +  # Visibility
-                ['0', 'No data', [], [], "Click generate to start Version 6.0 comprehensive analysis"] +  # Basic stats
-                ['No data'] * 8 +  # Enhanced stats  
+        return ([hide_style] * 7 +  # Visibility
+                ['0', 'No data', [], [], [], "Click generate to start Version 6.0 comprehensive analysis"] +  # Basic stats
+                ['No data'] * 8 +  # Enhanced stats
                 ['No data'] * 12 +  # Advanced analytics
                 [empty_figure] * 3 +  # Charts
                 [None])  # Metrics store
@@ -1347,13 +1349,14 @@ def generate_comprehensive_enhanced_analysis_v6(n_clicks, file_data, processed_d
         print("✅ Version 6.0 comprehensive enhanced analysis completed successfully")
         
         return (
-            # Visibility outputs (6)
-            show_style, stats_style, show_style, show_style, show_style, show_style,
-            
-            # Basic stats outputs (5)
+            # Visibility outputs (7)
+            show_style, stats_style, show_style, show_style, show_style, show_style, show_style,
+
+            # Basic stats outputs (6)
             f"{enhanced_metrics.get('total_events', 0):,}",
             enhanced_metrics.get('date_range', 'Jan 1 - Dec 31, 2024'),
             device_table,
+            graph_elements,
             graph_elements,
             "🎉 Version 6.0 comprehensive enhanced analysis complete! Explore your advanced analytics dashboard with detailed insights, interactive charts, and export capabilities.",
             
@@ -1398,8 +1401,8 @@ def generate_comprehensive_enhanced_analysis_v6(n_clicks, file_data, processed_d
         hide_style = {'display': 'none'}
         error_figure = {'data': [], 'layout': {'title': f'Analysis Error: {str(e)}', 'plot_bgcolor': '#0F1419', 'paper_bgcolor': '#1A2332', 'font': {'color': '#F7FAFC'}}}
         
-        return ([hide_style] * 6 +  # Visibility
-                ['Error', 'Error', [], [], f"❌ Version 6.0 Analysis Error: {str(e)}"] +  # Basic stats
+        return ([hide_style] * 7 +  # Visibility
+                ['Error', 'Error', [], [], [], f"❌ Version 6.0 Analysis Error: {str(e)}"] +  # Basic stats
                 ['Error'] * 8 +  # Enhanced stats
                 ['Error'] * 12 +  # Advanced analytics
                 [error_figure] * 3 +  # Charts

--- a/ui/components/stats.py
+++ b/ui/components/stats.py
@@ -4,7 +4,8 @@ Enhanced statistics component with advanced metrics, charts, and export features
 """
 
 from dash import html, dcc
-from ui.components.graph import create_graph_container ###
+import dash_cytoscape as cyto
+from ui.themes.graph_styles import actual_default_stylesheet_for_graph
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
@@ -231,12 +232,12 @@ class EnhancedStatsComponent:
                     dcc.Graph(id='security-pie-chart', style={'height': '300px'})
                 ], style={'flex': '1', 'margin': '0 10px'}),
                 html.Div([
-                    create_graph_container()], style={'flex': '1', 'margin': '0 10px'}),
+                    self.create_mini_graph_container()], style={'flex': '1', 'margin': '0 10px'}),
                 html.Div([
                     dcc.Graph(id='heatmap-chart', style={'height': '300px'})
                 ], style={'flex': '1', 'margin': '0 10px'})
             ], style={'display': 'flex', 'marginTop': '20px'})
-            
+
         ], style={
             'padding': '20px',
             'backgroundColor': COLORS['surface'],
@@ -244,6 +245,22 @@ class EnhancedStatsComponent:
             'margin': '20px 0',
             'border': f'1px solid {COLORS["border"]}'
         })
+
+    def create_mini_graph_container(self):
+        """Small graph container with unique IDs to avoid duplicates"""
+        return html.Div(
+            id='mini-graph-container',
+            style={'display': 'none'},
+            children=[
+                cyto.Cytoscape(
+                    id='mini-onion-graph',
+                    layout={'name': 'cose', 'fit': True},
+                    style={'width': '100%', 'height': '300px'},
+                    elements=[],
+                    stylesheet=actual_default_stylesheet_for_graph
+                )
+            ]
+        )
     
     def create_export_section(self):
         """NEW: Export and download section"""


### PR DESCRIPTION
## Summary
- create dedicated mini graph container in `stats.py`
- update callbacks to update new mini graph container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_684275c5ea408320bcbc01f937143fac