### PR TITLE
Update dashboard layout and CSS

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,7 +168,7 @@ def create_fully_integrated_layout_v6(app_instance, main_logo_path, icon_upload_
     # Use main layout if available, otherwise create comprehensive fallback
     if components_available['main_layout'] and create_main_layout:
         try:
-            base_layout = create_main_layout(app_instance, main_logo_path, icon_upload_default)
+            base_layout = create_main_layout(app_instance)
             enhanced_layout = _integrate_enhanced_features_into_layout_v6(base_layout, main_logo_path)
             print("✅ Enhanced main layout with integrated features")
             return enhanced_layout

--- a/app_production.py
+++ b/app_production.py
@@ -52,11 +52,7 @@ def create_production_app():
     MAIN_LOGO_PATH = app.get_asset_url('logo_white.png')
     
     # Create main layout
-    app.layout = create_main_layout(
-        app_instance=app,
-        main_logo_path=MAIN_LOGO_PATH,
-        icon_upload_default=ICON_UPLOAD_DEFAULT
-    )
+    app.layout = create_main_layout(app)
     
     # Placeholder for registering callbacks using handler factories
     logger.info("✅ Production app created successfully")

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,543 +1,201 @@
-/* assets/styles.css - FIXED VERSION - Simplified and Conflict-Free */
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   CSS CUSTOM PROPERTIES
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
 :root {
-  --color-primary: #1B2A47;
-  --color-accent: #2196F3;
-  --color-accent-hover: #42A5F5;
-  --color-success: #2DBE6C;
-  --color-warning: #FFB020;
-  --color-critical: #E02020;
-  --color-background: #0F1419;
-  --color-surface: #1A2332;
-  --color-border: #2D3748;
-  --color-text-primary: #F7FAFC;
-  --color-text-secondary: #E2E8F0;
-  --color-text-tertiary: #A0AEC0;
-  
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
-  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
-  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
-  
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
-  --radius-xl: 12px;
-  
-  --transition-fast: 0.15s ease;
-  --transition-normal: 0.3s ease;
+  /* Base font sizes */
+  --font-size-base: 16px;
+  --font-size-sm: 14px;
+  --font-size-md: 18px;
+  --font-size-lg: 24px;
+  --font-size-xl: 32px;
+
+  /* Card & layout spacing */
+  --card-padding: 20px;
+  --card-radius: 12px;
+  --card-gap: 20px;
+  --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  /* Button styling */
+  --btn-padding: 10px 20px;
+  --btn-radius: 8px;
 }
 
-/* ═══════════════════════════════════════════════════════════════════════════════
-   BASE STYLES
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
+/* ─────────────────────────────────────────────────────────────────────────────────
+   BODY + TYPOGRAPHY
+   ───────────────────────────────────────────────────────────────────────────────── */
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
-  background-color: var(--color-background) !important;
-  color: var(--color-text-primary) !important;
-  line-height: 1.5;
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
   margin: 0;
   padding: 0;
 }
 
-* {
-  box-sizing: border-box;
+h1, h2, h3, h4, h5, h6 {
+  color: var(--color-text-primary);
+  margin-bottom: 8px;
+  font-weight: 600;
 }
 
-/* ═══════════════════════════════════════════════════════════════════════════════
-   UPLOAD AREA STYLING
-   ═══════════════════════════════════════════════════════════════════════════════ */
+h1 { font-size: var(--font-size-xl); }
+h2 { font-size: var(--font-size-lg); }
+h3 { font-size: var(--font-size-md); }
 
-#upload-data {
-  transition: all var(--transition-normal) !important;
+/* ─────────────────────────────────────────────────────────────────────────────────
+   CARD GRID STYLING
+   ───────────────────────────────────────────────────────────────────────────────── */
+#stats-panels-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--card-gap);
+  margin: 20px;
 }
 
-#upload-data:hover {
-  border-color: var(--color-accent) !important;
-  background-color: rgba(33, 150, 243, 0.05) !important;
+.stat-card {
+  background-color: var(--color-surface);
+  padding: var(--card-padding);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.card-title {
+  font-size: var(--font-size-md);
+  margin-bottom: 10px;
+}
+
+.card-value {
+  font-size: var(--font-size-lg);
+  margin-bottom: 6px;
+}
+
+.card-subtext {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────────
+   BUTTON STYLING
+   ───────────────────────────────────────────────────────────────────────────────── */
+button, .dash-button {
+  padding: var(--btn-padding);
+  border-radius: var(--btn-radius);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+  text-transform: none;
+  background-color: var(--color-accent) !important;
+  color: #ffffff !important;
+  border: none !important;
+}
+
+button:hover, .dash-button:hover {
   transform: translateY(-2px);
-}
-
-#upload-icon {
-  transition: all var(--transition-normal) !important;
-}
-
-#upload-data:hover #upload-icon {
-  transform: scale(1.05);
-  opacity: 1 !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   BUTTONS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-button {
-  transition: all var(--transition-fast) !important;
-  font-family: inherit;
-}
-
-button:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 6px 14px rgba(33, 150, 243, 0.25);
+  background-color: var(--color-accent-hover) !important;
 }
 
 button:active {
-  transform: translateY(0);
+  transform: scale(0.98);
 }
 
-#confirm-and-generate-button:hover {
-  background-color: var(--color-accent-hover) !important;
-  box-shadow: var(--shadow-lg);
+/* ─────────────────────────────────────────────────────────────────────────────────
+   HEADER & UPLOAD SECTION
+   ───────────────────────────────────────────────────────────────────────────────── */
+#dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--color-surface);
+  padding: 20px;
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  margin: 20px;
 }
 
-/* ═══════════════════════════════════════════════════════════════════════════════
-   RADIO TOGGLE STYLING - FIXED
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-#manual-map-toggle {
-  justify-content: center !important;
-  align-items: center !important;
-  gap: 15px !important;
-  margin: 15px 0 !important;
+#upload-section {
+  background-color: var(--color-surface);
+  padding: var(--card-padding);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-/* Hide radio inputs completely */
-#manual-map-toggle input[type="radio"] {
-  display: none !important;
-  opacity: 0 !important;
-  position: absolute !important;
-  left: -9999px !important;
-  pointer-events: none !important;
+.upload-box {
+  border: 2px dashed var(--color-accent);
+  border-radius: var(--card-radius);
+  padding: 40px;
+  text-align: center;
+  width: 100%;
+  max-width: 600px;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
-/* Style labels as buttons */
-#manual-map-toggle label {
-  display: inline-block !important;
-  background-color: var(--color-border) !important;
-  color: var(--color-text-tertiary) !important;
-  border: 2px solid var(--color-border) !important;
-  border-radius: 20px !important;
-  padding: 12px 24px !important;
-  margin: 0 8px !important;
-  cursor: pointer !important;
-  transition: all var(--transition-normal) !important;
-  font-weight: 500 !important;
-  min-width: 120px !important;
-  text-align: center !important;
-  user-select: none !important;
-  font-size: 0.95rem !important;
-  box-shadow: var(--shadow-sm) !important;
-  font-family: inherit !important;
+.upload-box:hover {
+  background-color: rgba(33, 150, 243, 0.05);
+  border-color: var(--color-accent-hover);
 }
 
-/* Hover state */
-#manual-map-toggle label:hover {
-  background-color: #4A5568 !important;
-  border-color: #4A5568 !important;
-  transform: translateY(-1px) !important;
-  color: var(--color-text-secondary) !important;
+/* ─────────────────────────────────────────────────────────────────────────────────
+   CHART CONTROLS
+   ───────────────────────────────────────────────────────────────────────────────── */
+#chart-controls {
+  background-color: var(--color-surface);
+  padding: var(--card-padding);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px;
 }
 
-/* Selected states - CRITICAL STYLES */
-#manual-map-toggle input[value="no"]:checked + label {
-  background-color: var(--color-critical) !important;
-  border-color: var(--color-critical) !important;
-  color: white !important;
-  font-weight: 600 !important;
-  transform: translateY(-1px) !important;
-  box-shadow: 0 4px 12px rgba(224, 32, 32, 0.3) !important;
+/* ─────────────────────────────────────────────────────────────────────────────────
+   TABS CONTAINER
+   ───────────────────────────────────────────────────────────────────────────────── */
+#tabs-container {
+  display: flex;
+  gap: 10px;
+  margin: 0 20px 20px 20px;
 }
 
-#manual-map-toggle input[value="yes"]:checked + label {
-  background-color: var(--color-accent) !important;
-  border-color: var(--color-accent) !important;
-  color: white !important;
-  font-weight: 600 !important;
-  transform: translateY(-1px) !important;
-  box-shadow: 0 4px 12px rgba(33, 150, 243, 0.3) !important;
+.tab {
+  padding: 10px 20px;
+  cursor: pointer;
+  border-radius: var(--btn-radius);
+  background-color: var(--color-border);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-/* Focus styles for accessibility */
-#manual-map-toggle input[type="radio"]:focus + label {
-  outline: 2px solid var(--color-accent) !important;
-  outline-offset: 2px !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   DROPDOWN STYLING
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-.Select-control {
-  background-color: var(--color-surface) !important;
-  border-color: var(--color-border) !important;
-  color: var(--color-text-primary) !important;
-  transition: all var(--transition-fast) !important;
-}
-
-.Select-control:hover {
-  border-color: var(--color-accent) !important;
-}
-
-.Select-menu-outer {
-  background-color: var(--color-surface) !important;
-  border: 1px solid var(--color-border) !important;
-  border-radius: var(--radius-md) !important;
-  box-shadow: var(--shadow-lg) !important;
-  z-index: 1000 !important;
-}
-
-.Select-option {
-  background: transparent !important;
-  color: var(--color-text-primary) !important;
-  transition: background var(--transition-fast) !important;
-}
-
-.Select-option:hover {
-  background-color: var(--color-accent) !important;
-  color: white !important;
-}
-
-.Select-value-label {
-  color: var(--color-text-primary) !important;
-}
-
-.Select-placeholder {
-  color: var(--color-text-tertiary) !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   SLIDER STYLING
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-.rc-slider-rail {
-  background-color: var(--color-border) !important;
-  height: 6px !important;
-  border-radius: 3px !important;
-}
-
-.rc-slider-track {
-  background-color: var(--color-accent) !important;
-  height: 6px !important;
-  border-radius: 3px !important;
-}
-
-.rc-slider-handle {
-  border: 2px solid white !important;
-  background-color: var(--color-accent) !important;
-  width: 16px !important;
-  height: 16px !important;
-  margin-top: -5px !important;
-  box-shadow: var(--shadow-sm) !important;
-  transition: all var(--transition-fast) !important;
-}
-
-.rc-slider-handle:hover,
-.rc-slider-handle:focus {
-  box-shadow: 0 0 10px rgba(33, 150, 243, 0.5) !important;
-  background-color: var(--color-accent-hover) !important;
-}
-
-.rc-slider-mark-text {
-  color: var(--color-text-tertiary) !important;
-  font-size: 0.75rem !important;
-  font-weight: 500 !important;
-}
-
-.rc-slider-mark-text-active {
-  color: var(--color-accent) !important;
-  font-weight: 600 !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   STATISTICS PANELS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-/* display is controlled dynamically via Dash callbacks */
-/*#stats-panels-container {
-  display: flex !important;
-  flex-wrap: wrap !important;
-  justify-content: space-around !important;
-  gap: 20px !important;
-  margin: 20px auto !important;
-  max-width: 1200px !important;
-} */
-
-#stats-panels-container > div {
-  transition: all var(--transition-normal) !important;
-  border: 1px solid var(--color-border) !important;
-}
-
-#stats-panels-container > div:hover {
-  transform: translateY(-2px) !important;
-  box-shadow: var(--shadow-lg) !important;
-}
-
-#stats-panels-container h1 {
-  font-size: 2rem !important;
-  font-weight: 700 !important;
-  margin: 10px 0 !important;
-  color: var(--color-accent) !important;
-}
-
-#stats-panels-container h3 {
-  font-size: 1.1rem !important;
-  font-weight: 600 !important;
-  margin-bottom: 15px !important;
-  color: var(--color-text-primary) !important;
-}
-
-#stats-panels-container p {
-  font-size: 0.9rem !important;
-  margin: 5px 0 !important;
-  color: var(--color-text-secondary) !important;
-}
-
-#stats-panels-container table {
-  width: 100% !important;
-  font-size: 0.8rem !important;
-}
-
-#stats-panels-container th {
-  color: var(--color-text-primary) !important;
-  font-weight: 600 !important;
-  padding: 5px !important;
-  border-bottom: 1px solid var(--color-border) !important;
-}
-
-#stats-panels-container td {
-  padding: 5px !important;
-  color: var(--color-text-secondary) !important;
-  border-bottom: 1px solid rgba(45, 55, 72, 0.3) !important;
-}
-
-#stats-panels-container tr:hover td {
-  background-color: rgba(33, 150, 243, 0.1) !important;
-  color: var(--color-text-primary) !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   GRAPH STYLING
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-#onion-graph {
-  border-radius: var(--radius-lg) !important;
-  border: 1px solid var(--color-border) !important;
-}
-
-#tap-node-data-output {
-  background-color: var(--color-surface) !important;
-  color: var(--color-text-secondary) !important;
-  border: 1px solid var(--color-border) !important;
-  border-radius: var(--radius-md) !important;
-  font-family: 'Fira Code', monospace !important;
-  transition: all var(--transition-fast) !important;
-}
-
-#tap-node-data-output:hover {
-  background-color: var(--color-border) !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   PROCESSING STATUS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-#processing-status {
-  background: linear-gradient(135deg, rgba(33, 150, 243, 0.1), rgba(33, 150, 243, 0.2)) !important;
-  border: 1px solid rgba(33, 150, 243, 0.3) !important;
-  border-radius: var(--radius-lg) !important;
-  padding: 15px 20px !important;
-  margin: 20px auto !important;
-  max-width: 600px !important;
-  text-align: center !important;
-  font-weight: 600 !important;
-  font-size: 1rem !important;
-  color: var(--color-accent) !important;
-  transition: all var(--transition-normal) !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   FORM ELEMENTS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-input, select, textarea {
-  background-color: var(--color-surface) !important;
-  border: 1px solid var(--color-border) !important;
-  color: var(--color-text-primary) !important;
-  border-radius: var(--radius-md) !important;
-  transition: all var(--transition-fast) !important;
-}
-
-input:focus, select:focus, textarea:focus {
-  border-color: var(--color-accent) !important;
-  box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.1) !important;
-  outline: none !important;
-}
-
-label {
-  color: var(--color-text-primary) !important;
-  font-weight: 500 !important;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   SCROLLBAR STYLING
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--color-surface);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--color-border);
-  border-radius: 4px;
-  transition: background var(--transition-fast);
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-accent);
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   ANIMATIONS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes slideUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.fade-in {
-  animation: fadeIn 0.3s ease-out;
-}
-
-.slide-up {
-  animation: slideUp 0.4s ease-out;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   RESPONSIVE DESIGN
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-@media (max-width: 768px) {
-  #stats-panels-container {
-    flex-direction: column !important;
-    gap: 15px !important;
-  }
-  
-  #stats-panels-container > div {
-    margin: 0 auto !important;
-    width: 100% !important;
-    max-width: 400px !important;
-  }
-  
-  #manual-map-toggle {
-    flex-direction: column !important;
-    gap: 10px !important;
-  }
-  
-  #manual-map-toggle label {
-    min-width: 150px !important;
-    margin: 0 !important;
-  }
-  
-  #upload-data {
-    width: 90% !important;
-    min-height: 150px !important;
-  }
-  
-  #upload-icon {
-    width: 80px !important;
-    height: 80px !important;
-  }
-}
-
-@media (max-width: 576px) {
-  body {
-    font-size: 14px !important;
-  }
-  
-  h1, h2, h3, h4 {
-    font-size: 1.2em !important;
-  }
-  
-  #manual-map-toggle label {
-    padding: 10px 20px !important;
-    font-size: 0.9rem !important;
-  }
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   UTILITY CLASSES
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-.text-center { text-align: center !important; }
-.text-left { text-align: left !important; }
-.text-right { text-align: right !important; }
-
-.mt-10 { margin-top: 10px !important; }
-.mt-20 { margin-top: 20px !important; }
-.mb-10 { margin-bottom: 10px !important; }
-.mb-20 { margin-bottom: 20px !important; }
-
-.p-10 { padding: 10px !important; }
-.p-20 { padding: 20px !important; }
-
-.border-radius { border-radius: var(--radius-md) !important; }
-.box-shadow { box-shadow: var(--shadow-md) !important; }
-
-.transition { transition: all var(--transition-normal) !important; }
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   FIXES FOR DASH COMPONENTS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-/* Ensure Dash components inherit theme colors */
-div[data-dash-is-loading="true"] {
-  background-color: var(--color-surface) !important;
-  border: 1px solid var(--color-border) !important;
-  border-radius: var(--radius-md) !important;
-}
-
-/* Fix for RadioItems component */
-.form-check-input {
-  background-color: var(--color-surface) !important;
-  border-color: var(--color-border) !important;
-}
-
-.form-check-label {
-  color: var(--color-text-primary) !important;
-}
-
-/* Fix for loading states */
-._dash-loading {
-  background-color: var(--color-surface) !important;
-  border: 1px solid var(--color-border) !important;
-  border-radius: var(--radius-md) !important;
-}
-
-/* Ensure all text is readable */
-* {
-  color: inherit;
-}
-
-/* Final override for any missed text elements */
-p, span, div, li, td, th {
+.tab.active {
+  background-color: var(--color-accent);
   color: var(--color-text-primary);
 }
 
-h1, h2, h3, h4, h5, h6 {
-  color: var(--color-text-primary) !important;
+/* ─────────────────────────────────────────────────────────────────────────────────
+   EXPORT CONTROLS
+   ───────────────────────────────────────────────────────────────────────────────── */
+#export-buttons {
+  display: flex;
+  gap: 10px;
+  margin: 20px;
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────────
+   RESPONSIVE ADJUSTMENTS
+   ───────────────────────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  #dashboard-header, #upload-section, #chart-controls, #tabs-container {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+/* === custom.css END === */

--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -1,500 +1,248 @@
-# ui/pages/main_page.py - FIXED VERSION - Removes UI Conflicts
+import dash
+from dash import Dash, html, dcc, Input, Output
 
-"""
-Main page layout - STREAMLINED AND CONFLICT-FREE
-All callbacks are handled by unified handler in app.py
-"""
+# Temporary Dash app to generate asset URL
+_tmp = Dash(__name__)
+CUSTOM_CSS = _tmp.get_asset_url("custom.css")
 
-from dash import html, dcc
-import dash_cytoscape as cyto
-from ui.components.classification import create_classification_component
-
-from ui.themes.style_config import COLORS, TYPOGRAPHY, SPACING, BORDER_RADIUS
-from ui.themes.helpers import (
-    get_button_style,
-    get_card_style,
-    get_card_container_style,
-    get_section_header_style,
-)
-
-# Fallback constants
-REQUIRED_INTERNAL_COLUMNS = {
-    'Timestamp': 'Timestamp (Event Time)',
-    'UserID': 'UserID (Person Identifier)',
-    'DoorID': 'DoorID (Device Name)',
-    'EventType': 'EventType (Access Result)'
-}
+# Main Dash app with external stylesheet
+app = Dash(__name__, external_stylesheets=[CUSTOM_CSS], suppress_callback_exceptions=True)
 
 
-# Instantiate the reusable classification component for entrance verification
-classification_component = create_classification_component()
-
-def create_main_layout(app_instance, main_logo_path, icon_upload_default):
-    """
-    Creates the main application layout - STREAMLINED VERSION
-    """
-    
-    layout = html.Div(
+def overview_layout():
+    return html.Div(
+        id="overview-content",
         children=[
-            # Main Header Bar
-            create_main_header(main_logo_path),
-
-            # Upload Section - SIMPLIFIED
-            create_upload_section(icon_upload_default),
-
-            # Interactive Setup Container - SIMPLIFIED
-            create_interactive_setup_container(),
-
-            # Processing Status
             html.Div(
-                id='processing-status',
-                style={
-                    'marginTop': SPACING['md'],
-                    'color': COLORS['accent'],
-                    'textAlign': 'center',
-                    'fontSize': TYPOGRAPHY['text_base'],
-                    'fontWeight': TYPOGRAPHY['font_medium']
-                }
-            ),
-
-            # Results Section - HIDDEN until processing
-            create_results_section(),
-
-            # Data Stores
-            create_data_stores(),
-        ],
-        style={
-            'backgroundColor': COLORS['background'],
-            'padding': SPACING['md'],
-            'minHeight': '100vh',
-            'fontFamily': 'Inter, system-ui, sans-serif'
-        }
-    )
-
-    return layout
-
-def create_main_header(main_logo_path):
-    """Creates the main header bar"""
-    header_style = get_card_style()
-    header_style.update({
-        'display': 'flex',
-        'alignItems': 'center',
-        'justifyContent': 'center',
-        'padding': f"{SPACING['md']} {SPACING['xl']}",
-        'marginBottom': SPACING['xl'],
-    })
-    return html.Div(
-        style=header_style,
-        children=[
-            html.Img(src=main_logo_path, style={'height': '40px', 'marginRight': SPACING['base']}),
-            html.H1(
-                "Enhanced Analytics Dashboard",
-                style={
-                    'fontSize': TYPOGRAPHY['text_3xl'],
-                    'margin': '0',
-                    'color': COLORS['text_primary'],
-                    'fontWeight': TYPOGRAPHY['font_semibold']
-                }
-            )
-        ]
-    )
-
-def create_upload_section(icon_upload_default):
-    """Upload section - SIMPLIFIED"""
-    return html.Div([
-        dcc.Upload(
-            id='upload-data',
-            children=html.Div([
-                html.Img(
-                    id='upload-icon',
-                    src=icon_upload_default,
-                    style={
-                        'width': '96px',
-                        'height': '96px',
-                        'marginBottom': SPACING['base'],
-                        'opacity': '0.8'
-                    }
-                ),
-                html.H3(
-                    "Drop your CSV or JSON file here",
-                    style={
-                        'margin': '0',
-                        'fontSize': '1.2rem',
-                        'fontWeight': TYPOGRAPHY['font_semibold'],
-                        'color': COLORS['text_primary'],
-                        'marginBottom': SPACING['xs']
-                    }
-                ),
-                html.P(
-                    "or click to browse",
-                    style={
-                        'margin': '0',
-                        'fontSize': '0.9rem',
-                        'color': COLORS['text_secondary'],
-                    }
-                ),
-            ], style={'textAlign': 'center', 'padding': SPACING['md']}),
-            style={
-                'width': '70%',
-                'maxWidth': '600px',
-                'minHeight': '180px',
-                'borderRadius': BORDER_RADIUS['xl'],
-                'textAlign': 'center',
-                'margin': f"0 auto {SPACING['xl']} auto",
-                'display': 'flex',
-                'alignItems': 'center',
-                'justifyContent': 'center',
-                'cursor': 'pointer',
-                'transition': 'all 0.3s ease',
-                'border': f'2px dashed {COLORS["border"]}',
-                'backgroundColor': COLORS['surface'],
-            },
-            multiple=False,
-            accept='.csv,.json'
-        )
-    ])
-
-def create_interactive_setup_container():
-    """Interactive setup container - SIMPLIFIED"""
-    return html.Div(
-        id='interactive-setup-container',
-        style={'display': 'none'},
-        children=[
-            # Step 1: CSV Header Mapping
-            create_mapping_section(),
-
-            # Step 2 & 3: Entrance Verification Section (facility setup and classification)
-            classification_component.create_entrance_verification_section(),
-
-            # Generate Button
-            html.Button(
-                'Confirm Selections & Generate Analysis',
-                id='confirm-and-generate-button',
-                n_clicks=0,
-                style={
-                    **get_button_style(),
-                    'width': '100%',
-                    'maxWidth': '400px',
-                    'margin': f"{SPACING['xl']} auto",
-                    'display': 'block',
-                    'fontSize': TYPOGRAPHY['text_lg']
-                }
-            )
-        ]
-    )
-
-def create_mapping_section():
-    """Step 1: Map CSV Headers (wrapped in mapping-ui-section for callback control)"""
-    return html.Div(
-        id='mapping-ui-section',  # ✅ Enables callback to toggle visibility
-        style={**get_card_container_style(padding=SPACING['lg'], margin_bottom=SPACING['md']), 'display': 'none'},
-        children=[
-            html.H4(
-                "Step 1: Map CSV Headers",
-                style=get_section_header_style()
-            ),
-            html.P(
-                "Map your CSV columns to the required fields below:",
-                style={
-                    'color': COLORS['text_secondary'],
-                    'fontSize': '0.9rem',
-                    'marginBottom': SPACING['md'],
-                    'textAlign': 'center'
-                }
-            ),
-
-            # Dropdown area
-            html.Div(id='dropdown-mapping-area'),
-
-            # Confirm button
-            html.Button(
-                'Confirm Header Mapping',
-                id='confirm-header-map-button',
-                n_clicks=0,
-                style={
-                    **get_button_style('success'),
-                    'display': 'none',  # Hidden until dropdowns are created
-                    'margin': f"{SPACING['md']} auto"
-                }
-            )
-        ]
-    )
-
-def create_facility_setup():
-    """Step 2: Facility Setup"""
-    return html.Div([
-        html.H4(
-            "Step 2: Facility Setup",
-            style=get_section_header_style()
-        ),
-        
-        # Number of floors
-        html.Div([
-            html.Label(
-                "How many floors are in the facility?",
-                style={
-                    'color': COLORS['text_primary'],
-                    'fontWeight': TYPOGRAPHY['font_semibold'],
-                    'fontSize': '1rem',
-                    'marginBottom': SPACING['sm'],
-                    'display': 'block',
-                    'textAlign': 'center'
-                }
-            ),
-            dcc.Slider(
-                id="num-floors-input",
-                min=1,
-                max=20,
-                step=1,
-                value=4,
-                marks={i: str(i) for i in range(0, 101, 5)},
-                tooltip={"always_visible": False, "placement": "bottom"}
-            ),
-            html.Div(
-                id="num-floors-display",
-                children="4 floors",
-                style={
-                    "fontSize": "0.9rem",
-                    "color": COLORS['text_secondary'],
-                    "marginTop": SPACING['sm'],
-                    "textAlign": "center",
-                    "fontWeight": TYPOGRAPHY['font_semibold']
-                }
-            ),
-        ], style={'marginBottom': SPACING['md']}),
-        
-        # Manual classification toggle
-        html.Div([
-            html.Label(
-                "Enable Manual Door Classification?",
-                style={
-                    'color': COLORS['text_primary'],
-                    'fontWeight': TYPOGRAPHY['font_semibold'],
-                    'fontSize': '1rem',
-                    'marginBottom': SPACING['base'],
-                    'display': 'block',
-                    'textAlign': 'center'
-                }
-            ),
-            dcc.RadioItems(
-                id='manual-map-toggle',
-                options=[
-                    {'label': ' No (Automatic)', 'value': 'no'},
-                    {'label': ' Yes (Manual)', 'value': 'yes'}
-                ],
-                value='no',
-                inline=True,
-                style={'textAlign': 'center'},
-                labelStyle={
-                    'display': 'inline-block',
-                    'marginRight': SPACING['md'],
-                    'padding': f"{SPACING['sm']} {SPACING['lg']}",
-                    'backgroundColor': COLORS['border'],
-                    'color': COLORS['text_secondary'],
-                    'borderRadius': BORDER_RADIUS['full'],
-                    'cursor': 'pointer',
-                    'transition': 'all 0.3s ease'
-                }
-            ),
-        ])
-    ], style=get_card_container_style(padding=SPACING['lg'], margin_bottom=SPACING['md']))
-
-def create_classification_section():
-    """Step 3: Door Classification (conditional)"""
-    return html.Div(
-        id="door-classification-table-container",
-        style={'display': 'none'},
-        children=[
-            html.Div([
-                html.H4(
-                    "Step 3: Door Classification",
-                    style=get_section_header_style()
-                ),
-                html.P(
-                    "Classify each door below:",
-                    style={
-                        'color': COLORS['text_secondary'],
-                        'marginBottom': SPACING['md'],
-                        'textAlign': 'center'
-                    }
-                ),
-                html.Div(id="door-classification-table")
-            ], style=get_card_container_style(padding=SPACING['lg'], margin_bottom=0))
-        ]
-    )
-
-def create_results_section():
-    """Results section - hidden until processing complete"""
-    return html.Div([
-        # Custom Header (hidden)
-        html.Div(
-            id='yosai-custom-header',
-            style={'display': 'none'},
-            children=[
-                html.Div([
-                    html.H2(
-                        "📊 Analysis Results",
-                        style={
-                            'color': COLORS['text_primary'],
-                            'textAlign': 'center',
-                            'margin': '0',
-                            'fontSize': TYPOGRAPHY['text_2xl']
-                        }
-                    )
-                ], style=get_card_container_style(padding=SPACING['lg'], margin_bottom=SPACING['md']))
-            ]
-        ),
-
-        # Statistics Panels (hidden)
-        create_stats_panels(),
-
-        # Graph Container (hidden)
-        create_graph_container(),
-
-        # Analytics Section (initially hidden)
-        html.Div(
-            id='analytics-section',
-            style={'display': 'none'},
-            children=[
-                html.H2("📈 Advanced Analytics", style={'textAlign': 'center'}),
-                html.Div(id='analytics-detailed-breakdown')
-            ]
-        ),
-
-        # Charts Section (hidden until data is ready)
-        html.Div(
-            id='charts-section',
-            style={'display': 'none'},
-            children=[
-                html.H2("📊 Data Visualization", style={'textAlign': 'center'})
-            ]
-        ),
-
-        # Export Section (hidden until data is ready)
-        html.Div(
-            id='export-section',
-            style={'display': 'none'},
-            children=[
-                html.H2("📤 Export & Reports", style={'textAlign': 'center'})
-            ]
-        )
-    ])
-
-
-def create_stats_panels():
-    """Statistics panels"""
-    panel_style = get_card_container_style(padding=SPACING['lg'], margin_bottom=0)
-    panel_style.update({
-        'flex': '1',
-        'margin': f"0 {SPACING['sm']}",
-        'textAlign': 'center',
-        'minWidth': '200px'
-    })
-
-    return html.Div(
-        id='stats-panels-container',
-        style={'display': 'none'},
-        children=[
-            # Access Events Panel
-            html.Div([
-                html.H3("Access Events", style={'color': COLORS['text_primary'], 'marginBottom': SPACING['sm']}),
-                html.H1(id="total-access-events-H1", style={'color': COLORS['accent'], 'margin': f"{SPACING['sm']} 0"}),
-                html.P(id="event-date-range-P", style={'color': COLORS['text_secondary'], 'fontSize': '0.9rem'})
-            ], style=panel_style),
-
-            # Statistics Panel
-            html.Div([
-                html.H3("Summary", style={'color': COLORS['text_primary'], 'marginBottom': SPACING['sm']}),
-                html.P(id="stats-date-range-P", style={'color': COLORS['text_secondary'], 'fontSize': '0.8rem'}),
-                html.P(id="stats-days-with-data-P", style={'color': COLORS['text_secondary'], 'fontSize': '0.8rem'}),
-                html.P(id="stats-num-devices-P", style={'color': COLORS['text_secondary'], 'fontSize': '0.8rem'}),
-                html.P(id="stats-unique-tokens-P", style={'color': COLORS['text_secondary'], 'fontSize': '0.8rem'})
-            ], style=panel_style),
-
-            # Active Devices Panel
-            html.Div([
-                html.H3("Top Devices", style={'color': COLORS['text_primary'], 'marginBottom': SPACING['sm']}),
-                html.Table([
-                    html.Thead(html.Tr([
-                        html.Th("Device", style={'color': COLORS['text_primary'], 'fontSize': '0.8rem'}),
-                        html.Th("Events", style={'color': COLORS['text_primary'], 'fontSize': '0.8rem'})
-                    ])),
-                    html.Tbody(id='most-active-devices-table-body')
-                ], style={'width': '100%', 'fontSize': '0.8rem'})
-            ], style=panel_style)
-        ]
-    )
-
-def create_graph_container():
-    """Graph visualization container"""
-    return html.Div(
-        id='graph-output-container',
-        style={'display': 'none'},
-        children=[
-            html.H2(
-                "🗺️ Facility Layout Model",
-                style={
-                    'textAlign': 'center',
-                    'color': COLORS['text_primary'],
-                    'marginBottom': SPACING['md'],
-                    'fontSize': TYPOGRAPHY['text_2xl']
-                }
-            ),
-            html.Div(
+                id="stats-panels-container",
                 children=[
-                    cyto.Cytoscape(
-                        id='onion-graph',
-                        layout={'name': 'cose', 'fit': True},
-                        style={
-                            'width': '100%',
-                            'height': '500px',
-                            'backgroundColor': COLORS['background'],
-                            'borderRadius': BORDER_RADIUS['lg']
-                        },
-                        elements=[],
-                        stylesheet=[
-                            {
-                                'selector': 'node',
-                                'style': {
-                                    'background-color': COLORS['accent'],
-                                    'label': 'data(label)',
-                                    'color': COLORS['text_on_accent'],
-                                    'text-valign': 'center',
-                                    'width': 40,
-                                    'height': 40
-                                }
-                            },
-                            {
-                                'selector': 'edge',
-                                'style': {
-                                    'line-color': COLORS['border'],
-                                    'width': 2
-                                }
-                            }
-                        ]
-                    )
+                    html.Div(
+                        id="card-access",
+                        className="stat-card",
+                        children=[
+                            html.H3("Access Events", className="card-title"),
+                            html.H4("2,161", className="card-value"),
+                            html.Div("21.01.2025 – 21.01.2025", className="card-subtext"),
+                        ],
+                    ),
+                    html.Div(
+                        id="card-device",
+                        className="stat-card",
+                        children=[
+                            html.H3("Device Analytics", className="card-title"),
+                            html.H4("Total: 4 devices", className="card-value"),
+                            html.Div("Access Granted: 432", className="card-subtext"),
+                        ],
+                    ),
+                    html.Div(
+                        id="card-peak",
+                        className="stat-card",
+                        children=[
+                            html.H3("Peak Activity", className="card-title"),
+                            html.H4("Peak: 9:00", className="card-value"),
+                            html.Div("Busiest: Tuesday", className="card-subtext"),
+                        ],
+                    ),
                 ],
-                style=get_card_container_style(padding=SPACING['lg'], margin_bottom=0)
-            ),
-            html.Pre(
-                id='tap-node-data-output',
-                children="Generate analysis to see the facility layout. Tap nodes for details.",
-                style={**get_card_container_style(padding=SPACING['base'], margin_bottom=0),
-                       'color': COLORS['text_secondary'],
-                       'marginTop': SPACING['md'],
-                       'textAlign': 'center',
-                       'fontSize': '0.9rem'}
             )
-        ]
+        ],
     )
 
-def create_data_stores():
-    """Create all data store components"""
-    return html.Div([
-        dcc.Store(id='uploaded-file-store'),
-        dcc.Store(id='csv-headers-store'),
-        dcc.Store(id='column-mapping-store', storage_type='local'),
-        dcc.Store(id='all-doors-from-csv-store'),
-        dcc.Store(id='manual-door-classifications-store', storage_type='local'),
-        dcc.Store(id='num-floors-store', data=4),
-    ])
+
+def advanced_layout():
+    return html.Div(
+        id="advanced-content",
+        children=[
+            html.Div(
+                id="stats-panels-container",
+                children=[
+                    html.Div(
+                        id="card-traffic",
+                        className="stat-card",
+                        children=[
+                            html.H3("Traffic Pattern", className="card-title"),
+                            dcc.Graph(id="graph-traffic"),
+                        ],
+                    ),
+                    html.Div(
+                        id="card-security-score",
+                        className="stat-card",
+                        children=[
+                            html.H3("Security Score", className="card-title"),
+                            dcc.Graph(id="graph-security-score"),
+                        ],
+                    ),
+                    html.Div(
+                        id="card-usage",
+                        className="stat-card",
+                        children=[
+                            html.H3("Usage Efficiency", className="card-title"),
+                            dcc.Graph(id="graph-usage"),
+                        ],
+                    ),
+                    html.Div(
+                        id="card-anomaly",
+                        className="stat-card",
+                        children=[
+                            html.H3("Anomaly Detection", className="card-title"),
+                            dcc.Graph(id="graph-anomaly"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def export_layout():
+    return html.Div(
+        id="export-content",
+        children=[
+            html.Div(
+                id="export-buttons",
+                children=[
+                    html.Button("\ud83d\udcca Export Stats CSV", id="export-csv", className="dash-button"),
+                    html.Button("\ud83d\udcc9 Download Charts", id="download-charts", className="dash-button"),
+                    html.Button("\ud83e\uddfe Generate Report", id="generate-report", className="dash-button"),
+                    html.Button("\ud83d\udd04 Refresh Data", id="refresh-data", className="dash-button"),
+                ],
+            )
+        ],
+    )
+
+
+def create_main_layout(app_instance: Dash) -> html.Div:
+    return html.Div(
+        id="app-container",
+        children=[
+            # ─────── Dashboard Header ───────
+            html.Div(
+                id="dashboard-header",
+                children=[
+                    html.Div(
+                        children=[
+                            html.Img(src=app_instance.get_asset_url("logo.png"), style={"height": "40px"}),
+                            html.Span(" Enhanced Analytics Dashboard", style={"fontSize": "24px", "fontWeight": "700", "marginLeft": "10px"}),
+                        ],
+                        style={"display": "flex", "alignItems": "center"},
+                    ),
+                    html.Button("Advanced View \u23F7", id="advanced-view-button", n_clicks=0),
+                ],
+            ),
+
+            # ─────── Top Row: Upload + Chart Controls ───────
+            html.Div(
+                id="top-row",
+                children=[
+                    html.Div(
+                        id="upload-section",
+                        className="card",
+                        children=[
+                            html.Div(
+                                className="upload-box",
+                                children=[
+                                    html.I(className="fa fa-upload fa-2x", style={"marginBottom": "10px", "color": "var(--color-text-secondary)"}),
+                                    html.Div("Drop your CSV or JSON file here", style={"fontSize": "18px", "fontWeight": "500", "marginBottom": "5px"}),
+                                    html.Div("or click to browse", style={"fontSize": "14px", "color": "var(--color-text-tertiary)"}),
+                                ],
+                            )
+                        ],
+                    ),
+                    html.Div(
+                        id="chart-controls",
+                        className="card",
+                        children=[
+                            html.Div("Chart Type:", style={"fontWeight": "600", "marginBottom": "5px"}),
+                            dcc.Dropdown(
+                                id="chart-type-dropdown",
+                                options=[
+                                    {"label": "Hourly Activity", "value": "hourly"},
+                                    {"label": "Daily Trends", "value": "daily"},
+                                    {"label": "Device Summary", "value": "device"},
+                                ],
+                                value="hourly",
+                                clearable=False,
+                                style={"marginBottom": "15px"},
+                            ),
+                            html.Div(
+                                children=[
+                                    html.Button("\ud83d\udd0d Filter", id="filter-button", className="dash-button"),
+                                    html.Button("\ud83d\uddbd Time Range", id="timerange-button", className="dash-button", style={"marginLeft": "10px"}),
+                                ],
+                                style={"display": "flex"},
+                            ),
+                        ],
+                    ),
+                ],
+                style={"display": "grid", "gridTemplateColumns": "repeat(auto-fit, minmax(320px, 1fr))", "gap": "20px", "padding": "0 20px"},
+            ),
+
+            # ─────── Tabs ───────
+            html.Div(
+                id="tabs-container",
+                children=[
+                    html.Div("Overview", id="tab-overview", className="tab active"),
+                    html.Div("Advanced", id="tab-advanced", className="tab"),
+                    html.Div("Export", id="tab-export", className="tab"),
+                ],
+            ),
+
+            # ─────── Tab Content (filled by callback) ───────
+            html.Div(id="tab-content"),
+        ],
+    )
+
+
+def register_callbacks(app_instance: Dash):
+    @app_instance.callback(
+        Output("tab-content", "children"),
+        [
+            Input("tab-overview", "n_clicks_timestamp"),
+            Input("tab-advanced", "n_clicks_timestamp"),
+            Input("tab-export", "n_clicks_timestamp"),
+        ],
+    )
+    def render_tab_content(ts_overview, ts_advanced, ts_export):
+        timestamps = {
+            "overview": ts_overview or 0,
+            "advanced": ts_advanced or 0,
+            "export": ts_export or 0,
+        }
+        active_tab = max(timestamps, key=timestamps.get)
+        if active_tab == "overview":
+            return overview_layout()
+        elif active_tab == "advanced":
+            return advanced_layout()
+        else:
+            return export_layout()
+
+    @app_instance.callback(
+        [
+            Output("tab-overview", "className"),
+            Output("tab-advanced", "className"),
+            Output("tab-export", "className"),
+        ],
+        [
+            Input("tab-overview", "n_clicks_timestamp"),
+            Input("tab-advanced", "n_clicks_timestamp"),
+            Input("tab-export", "n_clicks_timestamp"),
+        ],
+    )
+    def update_tab_active(ts_overview, ts_advanced, ts_export):
+        timestamps = {
+            "overview": ts_overview or 0,
+            "advanced": ts_advanced or 0,
+            "export": ts_export or 0,
+        }
+        active = max(timestamps, key=timestamps.get)
+        return [
+            "tab active" if active == "overview" else "tab",
+            "tab active" if active == "advanced" else "tab",
+            "tab active" if active == "export" else "tab",
+        ]
+
+
+if __name__ == "__main__":
+    app.layout = create_main_layout(app)
+    register_callbacks(app)
+    app.run_server(debug=True)


### PR DESCRIPTION
## Summary
- revamp main layout with grid-based cards and header
- replace `assets/custom.css` with polished theme
- update callback logic for tabs
- fix calls to `create_main_layout`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68427cbc5ccc832097a4e3c6b5b0b18c