### PR TITLE
Fix CSS rule error and update tab logic

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -87,7 +87,6 @@ button:hover, .dash-button:hover {
   background-color: var(--color-accent-hover) !important;
 }
 
-=
 button:active {
   transform: scale(0.98);
 }

--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -236,7 +236,7 @@ def register_callbacks(app_instance: Dash):
             "advanced": ts_advanced or 0,
             "export": ts_export or 0,
         }
-        active_tab = max(timestamps, key=timestamps.get)
+        active_tab = max(timestamps, key=lambda k: timestamps[k])
         if active_tab == "overview":
             return overview_layout()
         elif active_tab == "advanced":
@@ -262,7 +262,7 @@ def register_callbacks(app_instance: Dash):
             "advanced": ts_advanced or 0,
             "export": ts_export or 0,
         }
-        active = max(timestamps, key=timestamps.get)
+        active = max(timestamps, key=lambda k: timestamps[k])
         return [
             "tab active" if active == "overview" else "tab",
             "tab active" if active == "advanced" else "tab",


### PR DESCRIPTION
## Summary
- remove stray character in `assets/custom.css`
- use lambda in main page for `max()` key functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68429da98000832095068f70e48fe083