### PR TITLE
Remove debug toggle handler

### DIFF
--- a/ui/components/classification_handlers.py
+++ b/ui/components/classification_handlers.py
@@ -433,16 +433,6 @@ class ClassificationDataProcessor:
                 distribution['regular'] += 1
         
         return distribution
-def _register_debug_toggle_handler(self):
-    """Debug callback to see what's happening with the toggle"""
-    @self.app.callback(
-        Output('processing-status', 'children', allow_duplicate=True),
-        Input('manual-map-toggle', 'value'),
-        prevent_initial_call='initial_duplicate'
-    )
-    def debug_toggle_change(value):
-        logger.info(f"DEBUG: Toggle changed to: {value}")
-        return f"Debug: Toggle is now '{value}'"
 
 # Factory functions for easy handler creation
 def create_classification_handlers(app, classification_component=None):


### PR DESCRIPTION
## Summary
- clean up ClassificationHandlers by removing unused _register_debug_toggle_handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842ab19c5408320bc0d7a98eb5acfe5