### PR TITLE
Fix JSON upload support

### DIFF
--- a/app.py
+++ b/app.py
@@ -848,14 +848,17 @@ def enhanced_file_upload_with_processing_v6(contents, filename):
         content_type, content_string = contents.split(',')
         decoded = base64.b64decode(content_string)
         
-        if not filename.lower().endswith('.csv'):
-            print("❌ Not a CSV file")
-            return None, None, "Error: Please upload a CSV file", None, {'display': 'none'}, {}, None
-        
-        # Read and process CSV
-        df = pd.read_csv(io.StringIO(decoded.decode('utf-8')))
+        # Determine file type and load accordingly
+        if filename.lower().endswith('.csv'):
+            df = pd.read_csv(io.StringIO(decoded.decode('utf-8')))
+        elif filename.lower().endswith('.json'):
+            df = pd.read_json(io.StringIO(decoded.decode('utf-8')))
+        else:
+            print("❌ Unsupported file type")
+            return None, None, "Error: Please upload a CSV or JSON file", None, {'display': 'none'}, {}, None
+
         headers = df.columns.tolist()
-        print(f"✅ CSV loaded: {len(df)} rows, {len(headers)} columns")
+        print(f"✅ File loaded: {len(df)} rows, {len(headers)} columns")
         print(f"📋 Headers: {headers}")
         
         # Enhanced door extraction with better logic


### PR DESCRIPTION
## Summary
- allow JSON files in the upload callback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842b218dc688320b2d771af691aa65c