### PR TITLE
Improve main layout integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -204,7 +204,6 @@ def _integrate_enhanced_features_into_layout_v6(base_layout, main_logo_path):
         
         all_existing_ids = collect_existing_ids(base_children)
         print(f"🔍 Found existing IDs: {all_existing_ids}")
-        ######!!!!!
         
         def process_children(children):
             """Recursively process children and replace sections where needed"""
@@ -250,7 +249,19 @@ def _integrate_enhanced_features_into_layout_v6(base_layout, main_logo_path):
 
         enhanced_children = process_children(base_children)
 
-        # Add enhanced data stores    #####
+        # Add missing containers if not present
+        if 'processing-status' not in all_existing_ids:
+            enhanced_children.append(html.Div(id='processing-status', style={
+                'color': '#2196F3',
+                'textAlign': 'center',
+                'margin': '10px',
+                'fontSize': '16px',
+                'fontWeight': '500'
+            }))
+        if 'interactive-setup-container' not in all_existing_ids:
+            enhanced_children.append(_create_comprehensive_setup_container_v6())
+
+        # Add enhanced data stores
         enhanced_children.append(_create_enhanced_data_stores_v6())
         
         print(f"✅ Layout integration complete. Enhanced sections: {existing_sections}")
@@ -831,7 +842,8 @@ print(f"📊 Components status: {components_available}")
         Output('all-doors-from-csv-store', 'data'),
         Output('interactive-setup-container', 'style'),
         Output('upload-data', 'style'),
-        Output('processed-data-store', 'data')  # Store processed data
+        Output('processed-data-store', 'data'),  # Store processed data
+        Output('upload-icon', 'src'),            # NEW: change icon on success/fail
     ],
     Input('upload-data', 'contents'),
     State('upload-data', 'filename'),
@@ -841,7 +853,7 @@ def enhanced_file_upload_with_processing_v6(contents, filename):
     """Version 6.0 - Enhanced upload callback with comprehensive processing"""
     print(f"🔄 Version 6.0 upload callback triggered: {filename}")
     if not contents:
-        return None, None, "", None, {'display': 'none'}, {}, None
+        return None, None, "", None, {'display': 'none'}, {}, None, ICON_UPLOAD_DEFAULT
     
     try:
         print(f"📄 Processing file: {filename}")
@@ -857,7 +869,16 @@ def enhanced_file_upload_with_processing_v6(contents, filename):
             df = pd.read_json(io.StringIO(decoded.decode('utf-8')))
         else:
             print("❌ Unsupported file type")
-            return None, None, "Error: Please upload a CSV or JSON file", None, {'display': 'none'}, {}, None
+            return (
+                None,
+                None,
+                "Error: Please upload a CSV or JSON file",
+                None,
+                {'display': 'none'},
+                {},
+                None,
+                ICON_UPLOAD_FAIL,
+            )
 
         headers = df.columns.tolist()
         print(f"✅ File loaded: {len(df)} rows, {len(headers)} columns")
@@ -930,14 +951,30 @@ def enhanced_file_upload_with_processing_v6(contents, filename):
         }
         
         print("✅ Version 6.0 enhanced upload successful with comprehensive data processing")
-        return (contents, headers, 
-                f"✅ Uploaded: {filename} ({len(df):,} rows, {len(headers)} columns) - Ready for Version 6.0 enhanced analytics!",
-                doors, setup_style, upload_success_style, processed_data)
+        return (
+            contents,
+            headers,
+            f"✅ Uploaded: {filename} ({len(df):,} rows, {len(headers)} columns) - Ready for Version 6.0 enhanced analytics!",
+            doors,
+            setup_style,
+            upload_success_style,
+            processed_data,
+            ICON_UPLOAD_SUCCESS,
+        )
         
     except Exception as e:
         print(f"❌ Error in Version 6.0 enhanced upload: {e}")
         traceback.print_exc()
-        return None, None, f"❌ Error processing {filename}: {str(e)}", None, {'display': 'none'}, {}, None
+        return (
+            None,
+            None,
+            f"❌ Error processing {filename}: {str(e)}",
+            None,
+            {'display': 'none'},
+            {},
+            None,
+            ICON_UPLOAD_FAIL,
+        )
 
 # 2. Enhanced Mapping Callback with Auto-Suggestions
 @app.callback(

--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -1,6 +1,6 @@
 import dash
 from dash import Dash, html, dcc, Input, Output
-from ui.components.upload import create_simple_upload_component
+from ui.components.upload import create_enhanced_upload_component
 
 # Temporary Dash app to get the asset URL for custom.css
 _tmp = Dash(__name__)
@@ -116,6 +116,12 @@ def export_layout():
 
 
 def create_main_layout(app_instance: Dash) -> html.Div:
+    upload_component = create_enhanced_upload_component(
+        app_instance.get_asset_url("upload_file_csv_icon.png"),
+        app_instance.get_asset_url("upload_file_csv_icon_success.png"),
+        app_instance.get_asset_url("upload_file_csv_icon_fail.png"),
+    )
+
     return html.Div(
         id="app-container",
         children=[
@@ -149,9 +155,7 @@ def create_main_layout(app_instance: Dash) -> html.Div:
                         id="upload-section",
                         className="card",
                         children=[
-                            create_simple_upload_component(
-                                app_instance.get_asset_url("upload_file_csv_icon.png")
-                            ).create_upload_area()
+                            upload_component.create_upload_area(),
                         ],
                     ),
                     html.Div(
@@ -193,6 +197,17 @@ def create_main_layout(app_instance: Dash) -> html.Div:
                     "padding": "0 20px",
                 },
             ),
+            html.Div(
+                id="processing-status",
+                style={
+                    "color": "#2196F3",
+                    "textAlign": "center",
+                    "margin": "10px",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                },
+            ),
+            upload_component.create_interactive_setup_container(),
             # ─────── Tabs ───────
             html.Div(
                 id="tabs-container",
@@ -204,6 +219,12 @@ def create_main_layout(app_instance: Dash) -> html.Div:
             ),
             # ─────── Tab Content (filled by callback) ───────
             html.Div(id="tab-content"),
+
+            # Data stores required by callbacks
+            dcc.Store(id="uploaded-file-store"),
+            dcc.Store(id="csv-headers-store", storage_type="session"),
+            dcc.Store(id="processed-data-store", storage_type="session"),
+            dcc.Store(id="enhanced-metrics-store", storage_type="session"),
         ],
     )
 


### PR DESCRIPTION
## Summary
- include upload success/fail icons and interactive setup in main layout
- ensure production layout includes processing status and data stores
- remove stray debug comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842ca9387248320888309f813964765